### PR TITLE
Make method protected so it can be used for unconventional uses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/http-utils",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A collection of utilities for making http requests in a browser",
   "main": "lib/index.js",
   "repository": "git@github.com:VEuPathDB/web-http-utils.git",

--- a/src/FetchClientWithCredentials.ts
+++ b/src/FetchClientWithCredentials.ts
@@ -12,7 +12,7 @@ export class FetchClientWithCredentials extends FetchClient {
 
   protected readonly getUser = once(() => this.wdkService.getCurrentUser());
 
-  private readonly findUserRequestAuthKey = once(async () => {
+  protected readonly findUserRequestAuthKey = once(async () => {
     const user = await this.getUser();
     if (user.isGuest) {
       return String(user.id);


### PR DESCRIPTION
There are situations where it is useful to acquire the user's auth key. This PR allows that by making the associate method `protected`.