### PR TITLE
Add traceid header to requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "dependencies": {
     "fp-ts": "^2.11.5",
     "io-ts": "^2.2.16",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "@veupathdb/wdk-client": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@veupathdb/http-utils",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A collection of utilities for making http requests in a browser",
   "main": "lib/index.js",
   "repository": "git@github.com:VEuPathDB/web-http-utils.git",

--- a/src/FetchClient.ts
+++ b/src/FetchClient.ts
@@ -91,6 +91,6 @@ async function fetchResponseBody(response: Response) {
 }
 
 function generateTraceidHeaderValue() {
-  const traceId = uuid().replace(/-/g, '');
+  const traceId = uuid().replaceAll('-', '');
   return traceId;
 }

--- a/src/FetchClient.ts
+++ b/src/FetchClient.ts
@@ -1,3 +1,5 @@
+import { v4 as uuid } from 'uuid';
+
 /*
  * An "Api" is an abstraction for interacting with resources.
  *
@@ -41,6 +43,8 @@ export abstract class FetchClient {
   protected readonly baseUrl: string;
   protected readonly init: RequestInit;
   protected readonly fetchApi: Window['fetch'];
+  // Subclasses can set this to false to disable including a traceparent header with all requests.
+  protected readonly includeTraceidHeader: boolean = true;
 
   constructor(options: FetchApiOptions) {
     this.baseUrl = options.baseUrl;
@@ -60,6 +64,9 @@ export abstract class FetchClient {
         ...init.headers,
       },
     });
+    if (this.includeTraceidHeader) {
+      request.headers.set('traceid', generateTraceidHeaderValue());
+    }
     const response = await fetchApi(request);
     // TODO Make this behavior configurable
     if (response.ok) {
@@ -81,4 +88,9 @@ async function fetchResponseBody(response: Response) {
     : contentType.startsWith('application/json')
     ? response.json()
     : response.text();
+}
+
+function generateTraceidHeaderValue() {
+  const traceId = uuid().replace(/-/g, '');
+  return traceId;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15308,6 +15308,11 @@ uuid@^8.1.0, uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
This PR introduces the `traceid` header to requests. The value is a UUID (with hyphens removed). Subclasses of the `FetchClient` abstract class can disable this behavior, if needed, by setting the readonly field `includeTraceidHeader` to `false`.